### PR TITLE
Added support for create_attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,3 @@ Currently, the following endpoints are fully supported:
 The following endpoints are not fully supported:
 
 - The users endpoint is currently unsupported, feel free to implement support and submit a pull request.
-- The attachments endpoint is partially supported, the GET, UPDATE and DELETE operations are implemented, while the CREATE operation is not currently supported, since the endpoint uses the `multipart/form-data` content type instead of JSON. Feel free to implement support and submit a pull request.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Currently, the following endpoints are fully supported:
 - Notes endpoint
 - Document Properties endpoint
 - IssueLibrary endpoint 
+- Attachments endpoint
 
 The following endpoints are not fully supported:
 

--- a/dradis.py
+++ b/dradis.py
@@ -978,7 +978,7 @@ class Dradis():
         self._add_project_header(project_id)
         
         # Remove  application/json Content-type and let requests handle the multipart/format-data type + boundary automatically
-        self.__headers.pop('Content-type')
+        self.__headers.pop('Content-type', None)
         
         # REQUEST 
         result = self._action(url=url, header=self.__headers, req_type=req_type, files=files)

--- a/dradis.py
+++ b/dradis.py
@@ -977,11 +977,11 @@ class Dradis():
         # SET HEADERS
         self._add_project_header(project_id)
         
-        # Remove  application/json Content-type and let requests handle the multipart/format-data type + boundary automatically
-        self.__headers.pop('Content-type', None)
+        # headers object with previous headers except for Content-Type
+        headers = {k:v for k,v in self.__headers.items() if k != 'Content-Type'}
         
         # REQUEST 
-        result = self._action(url=url, header=self.__headers, req_type=req_type, files=files)
+        result = self._action(url=url, header=headers, req_type=req_type, files=files)
         
         # Cleanup headers
         self._cleanup_project_header()
@@ -989,11 +989,11 @@ class Dradis():
         return result
         
     def create_attachment(self, project_id: int, node_id: int, *attachments: Path):
-        """Create new attachment() on a node
+        """Create new attachment(s) on a node
 
         :param project_id: ID for the project
         :param node_id: ID for the node to create attachment for
-        :param attachment:s Path of attachment(s) to upload to a node
+        :param attachments: Path of attachment(s) to upload to a node
         """
 
         # BUILD URL

--- a/dradis.py
+++ b/dradis.py
@@ -965,13 +965,13 @@ class Dradis():
 
         return result
 
-    def create_attachment(self, project_id: int, node_id: int, attachement: Path, *args: Path):
-        """Create a new attachment
+    def create_attachment(self, project_id: int, node_id: int, attachment: Path, *args: Path):
+        """Create new attachment() on a node
 
         :param project_id: ID for the project
         :param node_id: ID for the node to create attachment for
-        :param attachement: Path of attachement to upload to a node
-        :*args: path(s) of additionnal attachement(s) to add to the upload request (optional)
+        :param attachment: Path of attachment to upload to a node
+        :*args: path(s) of additionnal attachment(s) to add to the upload request (optional)
         """
         # HTTP REQUEST TYPE
         req_type = "POST"
@@ -987,10 +987,10 @@ class Dradis():
         url = self.__url+endpoint
 
         # Add file to upload
-        if attachement.is_file():
-            files = [('files[]', (attachement.name, attachement.read_bytes()))]
+        if attachment.is_file():
+            files = [('files[]', (attachment.name, attachment.read_bytes()))]
         else :
-           raise Exception(f"{attachement.name} is not a valid file.")
+           raise Exception(f"{attachment.name} is not a valid file.")
 
         # Add additionnal file(s) to upload
         for file in args:


### PR DESCRIPTION
🆕 Implemented create_attachment
Create one or multiple new attachments on a node

function arguments :
        :param project_id: ID for the project
        :param node_id: ID for the node to create attachment for
        :param attachment: Path of attachment to upload to a node
        :*args: path(s) of additional attachment(s) to add to the upload request (optional)

pathlib Path now required to read files (from pathlib import Path)